### PR TITLE
Replace `ezsockets` with `tokio-websockets`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,17 +54,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,7 +61,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -80,17 +69,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atomic_enum"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6227a8d6fdb862bcb100c4314d0d9579e5cd73fa6df31a2e6f6e1acd3c5f1207"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "autocfg"
@@ -102,10 +80,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 name = "azure-speech"
 version = "0.2.3"
 dependencies = [
- "async-channel",
  "async-trait",
  "cpal",
- "ezsockets",
+ "futures-util",
  "hound",
  "iobuffer",
  "os_info",
@@ -118,6 +95,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tokio-websockets",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -138,12 +116,6 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -168,7 +140,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -182,15 +154,6 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "bumpalo"
@@ -270,15 +233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,51 +292,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
-
-[[package]]
-name = "data-encoding"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
 
 [[package]]
 name = "dyn-clone"
@@ -406,20 +319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enfync"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce8c1fbec15a38aced3838c4d7ea90a1403bd50364b5cfe8008e679df0c8dde"
-dependencies = [
- "async-trait",
- "futures",
- "tokio",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasmtimer",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,43 +335,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
 name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
-
-[[package]]
-name = "ezsockets"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d0a2b40e959bf072555d363e36a8579be0398596127273dcf73bdc0665e35c"
-dependencies = [
- "async-channel",
- "async-trait",
- "atomic_enum",
- "base64 0.21.7",
- "cfg-if",
- "enfync",
- "futures",
- "futures-util",
- "getrandom",
- "http 0.2.12",
- "tokio",
- "tokio-native-tls",
- "tokio-tungstenite",
- "tokio-tungstenite-wasm",
- "tracing",
- "tungstenite",
- "url",
- "wasm-bindgen-futures",
- "wasmtimer",
-]
 
 [[package]]
 name = "fastrand"
@@ -511,28 +377,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -540,17 +390,6 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -566,7 +405,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -587,7 +426,6 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -600,26 +438,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -645,7 +471,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -673,17 +499,6 @@ checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -700,7 +515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -711,7 +526,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "pin-project-lite",
 ]
@@ -732,7 +547,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.1.0",
+ "http",
  "http-body",
  "httparse",
  "itoa",
@@ -749,7 +564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
- "http 1.1.0",
+ "http",
  "hyper",
  "hyper-util",
  "rustls",
@@ -784,7 +599,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "hyper",
  "pin-project-lite",
@@ -979,13 +794,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1062,7 +878,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1072,16 +888,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -1102,7 +908,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1166,7 +972,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1250,7 +1056,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1396,13 +1202,13 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -1493,10 +1299,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1505,7 +1325,7 @@ version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "rustls-pki-types",
 ]
 
@@ -1596,7 +1416,7 @@ checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1624,15 +1444,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
+name = "sha1_smol"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sharded-slab"
@@ -1790,17 +1605,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
@@ -1867,7 +1671,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1897,32 +1701,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1959,38 +1762,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
-dependencies = [
- "futures-util",
- "log",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tungstenite",
-]
-
-[[package]]
-name = "tokio-tungstenite-wasm"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec8c7cf09b20184f946f114e3d8c0deca34368912c90100812861c14bb63b66"
-dependencies = [
- "futures-channel",
- "futures-util",
- "http 0.2.12",
- "httparse",
- "js-sys",
- "thiserror",
- "tokio",
- "tokio-tungstenite",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +1772,30 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64",
+ "bytes",
+ "fastrand",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "httparse",
+ "ring",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "sha1_smol",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tokio-util",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2066,7 +1861,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -2115,32 +1910,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 0.2.12",
- "httparse",
- "log",
- "native-tls",
- "rand",
- "sha1",
- "thiserror",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2180,12 +1949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "uuid"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,12 +1969,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2260,7 +2017,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2294,7 +2051,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2319,20 +2076,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtimer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f656cd8858a5164932d8a90f936700860976ec21eb00e0fe2aa8cab13f6b4cf"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot",
- "pin-utils",
- "slab",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,6 +2083,15 @@ checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2653,7 +2405,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ keywords = [
 ]
 
 [dependencies]
-tokio = { version = "1.40", features = ["sync"] }
+tokio = { version = "1.40", features = ["sync", "macros", "rt"] }
 tracing = { version = "0.1", default-features = false }
 tokio-websockets = { version = "0.10", features = ["client"] }
 futures-util = { version = "0.3", default-features = false, features = [ "std", "sink" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,10 @@ keywords = [
 ]
 
 [dependencies]
-tokio = { version = "=1.38", features = ["sync"] }
-tracing = "0.1"
-ezsockets = { version = "0.6", features = ["native-tls", "native_client"] }
+tokio = { version = "1.40", features = ["sync"] }
+tracing = { version = "0.1", default-features = false }
+tokio-websockets = { version = "0.10", features = ["client"] }
+futures-util = { version = "0.3", default-features = false, features = [ "std", "sink" ] }
 async-trait = "0.1"
 tokio-stream = { version = "0.1", features = ["sync"] }
 pin-project-lite = "0.2.14"
@@ -41,8 +42,14 @@ serde_json = "1.0.114"
 os_info = "3"
 
 ssml = "0.1.0"
-async-channel = "1.9.0" # needed for ezsockets 0.6 for call_with;
 
+[features]
+default = ["tws-rustls-native-roots", "tws-fastrand", "tws-smol-sha1"]
+tws-rustls-native-roots = ["tokio-websockets/rustls-webpki-roots", "tokio-websockets/ring"]
+tws-rustls-webpki-roots = ["tokio-websockets/rustls-native-roots", "tokio-websockets/ring"]
+tws-native-tls = ["tokio-websockets/native-tls"]
+tws-smol-sha1 = ["tokio-websockets/sha1_smol"]
+tws-fastrand = ["tokio-websockets/fastrand"]
 
 [dev-dependencies]
 tokio = { version = "1.36.0", features = ["full"] }

--- a/src/connector/client.rs
+++ b/src/connector/client.rs
@@ -1,163 +1,152 @@
 use crate::connector::message::Message;
-use async_trait::async_trait;
-use ezsockets::client::ClientCloseMode;
-use ezsockets::{ClientConfig, CloseCode, CloseFrame, Error};
-use tokio::sync::broadcast;
-use tokio::sync::oneshot;
+use futures_util::SinkExt;
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::StreamExt;
+use tokio_websockets::ClientBuilder;
+
+enum InternalMessage {
+    SendMessage(tokio_websockets::Message),
+    Subscribe(oneshot::Sender<crate::Result<broadcast::Receiver<crate::Result<Message>>>>),
+    Disconnect,
+}
 
 #[derive(Clone)]
 pub struct Client {
-    handle: ezsockets::Client<BaseClient>,
+    channel: mpsc::Sender<InternalMessage>,
 }
 
 impl Client {
     /// Create a new client.
-    pub(crate) fn new(handle: ezsockets::Client<BaseClient>) -> Self {
-        Self { handle }
+    fn new(channel: mpsc::Sender<InternalMessage>) -> Self {
+        Self { channel }
     }
 }
 impl Client {
     /// Send a text message to the server.
-    pub fn send_text(&self, text: impl Into<String>) -> crate::Result<()> {
-        self.handle.text(text)?;
+    pub async fn send_text(&self, text: impl Into<String>) -> crate::Result<()> {
+        self.channel
+            .send(InternalMessage::SendMessage(
+                tokio_websockets::Message::text(text.into()),
+            ))
+            .await?;
         Ok(())
     }
 
     /// Send a binary message to the server.
-    pub fn send_binary(&self, bytes: impl Into<Vec<u8>>) -> crate::Result<()> {
-        self.handle.binary(bytes)?;
+    pub async fn send_binary(&self, bytes: impl Into<Vec<u8>>) -> crate::Result<()> {
+        self.channel
+            .send(InternalMessage::SendMessage(
+                tokio_websockets::Message::binary(bytes.into()),
+            ))
+            .await?;
         Ok(())
     }
 
     /// Stream messages from the server.
     pub async fn stream(&self) -> crate::Result<BroadcastStream<crate::Result<Message>>> {
-        self.handle.call_with(Call::Subscribe).await.map_or(
-            Err(crate::Error::InternalError(
-                "Failed to subscribe to messages".to_string(),
-            )),
-            |rx| Ok(BroadcastStream::new(rx)),
-        )
+        let (sender, receiver) = oneshot::channel();
+        self.channel
+            .send(InternalMessage::Subscribe(sender))
+            .await?;
+        Ok(BroadcastStream::new(receiver.await.map_err(|_| {
+            crate::Error::InternalError("Failed to subscribe to messages".to_string())
+        })??))
     }
 }
 
 impl Client {
-    pub(crate) async fn connect(config: ClientConfig) -> crate::Result<Self> {
-        let (await_connection_tx, await_connection_rx) = oneshot::channel::<()>();
-        let (client, future) =
-            ezsockets::connect(|_| BaseClient::new(await_connection_tx), config).await;
+    pub(crate) async fn connect(config: ClientBuilder<'static>) -> crate::Result<Self> {
+        let (mut stream, _res) = config.connect().await.unwrap();
+        let (sender, mut receiver) = mpsc::channel(16);
+        tokio::spawn(async move {
+            let (broadcaster, _) = broadcast::channel(32);
+            let mut connected = true;
+            loop {
+                tokio::select! {
+                    msg = receiver.recv() => {
+                        let Some(msg) = msg else {
+                            // Receiving `None` here means the client has been dropped, so the task should stop as well.
+                            break;
+                        };
+                        match msg {
+                            InternalMessage::SendMessage(msg) => {
+                                let _ = stream.send(msg).await;
+                            },
+                            InternalMessage::Subscribe(c) => {
+                                if !connected {
+                                    // We got disconnected from the server for whatever reason. Since we are currently
+                                    // expecting a stream, now would be a good time to try to reconnect.
+                                    let mut last_error = None;
+                                    for i in 0..3 {
+                                        tracing::debug!("Reconncting ({i}/3)");
+                                        match config.connect().await {
+                                            Ok((new_stream, _)) => {
+                                                tracing::debug!("Reconnected successfully");
+                                                drop(last_error.take());
+                                                connected = true;
+                                                stream = new_stream;
+                                                break;
+                                            }
+                                            Err(e) => {
+                                                tracing::warn!("Failed to reconnect ({i}/3): {e}");
+                                                last_error.replace(e);
+                                            }
+                                        }
+                                    }
 
-        tokio::select! {
-            _ = await_connection_rx => {
-                tracing::debug!("Client is ready to send messages");
-                Ok(Client::new(client))
+                                    // If we still haven't reconnected, send the error to the client.
+                                    if let Some(err) = last_error.take() {
+                                        c.send(Err(crate::Error::ConnectionError(err.to_string()))).unwrap();
+                                        continue;
+                                    }
+                                }
+
+                                c.send(Ok(broadcaster.subscribe())).unwrap();
+                            },
+                            InternalMessage::Disconnect => {
+                                connected = false;
+                                let _ = stream.close().await;
+                            }
+                        }
+                    }
+                    msg = stream.next(), if connected => {
+                        let Some(msg) = msg else {
+                            // Receiving `None` here means the socket has been disconnected and can no longer receive messages.
+                            // We set `connected` to false just to make sure that the stream isn't polled again until we're reconnected.
+                            connected = false;
+                            continue;
+                        };
+                        match msg {
+                            Ok(msg) => {
+                                if msg.is_text() {
+                                    let text = msg.as_text().unwrap();
+                                    broadcaster.send(Message::try_from(text)).unwrap();
+                                } else if msg.is_binary() {
+                                    let bin = msg.as_payload();
+                                    broadcaster.send(Message::try_from(&**bin)).unwrap();
+                                } else if msg.is_close() {
+                                    connected = false;
+
+                                    let close = msg.as_close().unwrap();
+                                    tracing::info!(reason = ?close.0, msg = close.1, "disconnected from server");
+                                }
+                            },
+                            Err(e) => {
+                                tracing::warn!(?e, "connection errored");
+                                connected = false;
+                            }
+                        }
+                    }
+                }
             }
-            _ = future => {
-                tracing::error!("Connection closed before the client was ready to send messages");
-                Err(crate::Error::ServerDisconnect("Connection closed before the client was ready to send messages".to_string()))
-            }
-        }
+        });
+        Ok(Client::new(sender))
     }
 
     /// Disconnect the client.
     pub(crate) async fn disconnect(self) -> crate::Result<()> {
-        let _ = self.handle.close(None)?;
+        let _ = self.channel.send(InternalMessage::Disconnect).await?;
         Ok(())
-    }
-}
-
-pub(crate) enum Call {
-    Subscribe(async_channel::Sender<broadcast::Receiver<crate::Result<Message>>>),
-}
-
-pub(crate) struct BaseClient {
-    messages: broadcast::Sender<crate::Result<Message>>,
-    ready: Option<oneshot::Sender<()>>,
-}
-
-impl BaseClient {
-    pub(crate) fn new(ready: oneshot::Sender<()>) -> Self {
-        let (sender, _) = broadcast::channel(1024 * 5);
-        Self {
-            messages: sender,
-            ready: Some(ready),
-        }
-    }
-}
-
-#[async_trait]
-impl ezsockets::ClientExt for BaseClient {
-    type Call = Call;
-
-    async fn on_text(&mut self, text: String) -> Result<(), Error> {
-        tracing::debug!("Received text: {:?}", text);
-
-        return match text.try_into() {
-            Ok(value) => {
-                self.messages.send(Ok(value))?;
-                Ok(())
-            }
-            _ => Err(Error::from("Error parsing text".to_string())),
-        };
-    }
-
-    async fn on_binary(&mut self, bytes: Vec<u8>) -> Result<(), Error> {
-        tracing::debug!("Received binary: {:?}", bytes.len());
-        tracing::trace!("Received Binary data: {:?}", bytes);
-        return match bytes.try_into() {
-            Ok(value) => {
-                self.messages.send(Ok(value))?;
-                Ok(())
-            }
-            _ => Err(Error::from("Error parsing bytes".to_string())),
-        };
-    }
-
-    async fn on_call(&mut self, call: Self::Call) -> Result<(), Error> {
-        match call {
-            Call::Subscribe(respond_to) => {
-                let _ = respond_to.send(self.messages.subscribe()).await?;
-            }
-        };
-        Ok(())
-    }
-
-    async fn on_connect(&mut self) -> Result<(), Error> {
-        // send the ready signal.
-        // This is used to notify the connector that the client is ready to send messages.
-        if let Some(ready) = self.ready.take() {
-            let _ = ready.send(());
-        }
-
-        Ok(())
-    }
-
-    async fn on_close(&mut self, frame: Option<CloseFrame>) -> Result<ClientCloseMode, Error> {
-        tracing::debug!("Server close the connection...{:?}", frame);
-
-        match frame {
-            Some(CloseFrame { code, reason }) => {
-                let mode = match code {
-                    CloseCode::Restart | CloseCode::Again | CloseCode::Normal => {
-                        tracing::debug!("Reconnecting...");
-                        ClientCloseMode::Reconnect
-                    }
-                    _ => {
-                        tracing::debug!("Sending server error message...");
-                        self.messages.send(Err(crate::Error::ServerDisconnect(
-                            reason.clone().to_string(),
-                        )))?;
-                        tracing::debug!("Closing...");
-                        ClientCloseMode::Close
-                    }
-                };
-                tracing::debug!("Close mode: {:?}", mode);
-                Ok(mode)
-            }
-            None => {
-                tracing::debug!("Reconnecting...");
-                Ok(ClientCloseMode::Reconnect)
-            }
-        }
     }
 }

--- a/src/connector/client.rs
+++ b/src/connector/client.rs
@@ -146,7 +146,7 @@ impl Client {
 
     /// Disconnect the client.
     pub(crate) async fn disconnect(self) -> crate::Result<()> {
-        let _ = self.channel.send(InternalMessage::Disconnect).await?;
+        self.channel.send(InternalMessage::Disconnect).await?;
         Ok(())
     }
 }

--- a/src/connector/utils.rs
+++ b/src/connector/utils.rs
@@ -3,14 +3,14 @@ use crate::Headers;
 static CRLF: &str = "\r\n";
 static HEADER_JSON_SEPARATOR: &str = "\r\n\r\n";
 
-pub fn make_text_payload(headers: Headers, data: Option<String>) -> String {
+pub fn make_text_payload(headers: Headers, data: Option<&str>) -> String {
     let headers = transform_headers_to_string(headers);
-    let data = data.map_or(String::new(), |d| d);
+    let data = data.map_or("", |d| d);
 
     format!("{}{CRLF}{}", headers, data)
 }
 
-pub fn make_binary_payload(headers: Headers, data: Option<Vec<u8>>) -> Vec<u8> {
+pub fn make_binary_payload(headers: Headers, data: Option<&[u8]>) -> Vec<u8> {
     let headers = transform_headers_to_string(headers);
 
     let data_length = if let Some(ref d) = data { d.len() } else { 0 };
@@ -30,10 +30,10 @@ pub fn make_binary_payload(headers: Headers, data: Option<Vec<u8>>) -> Vec<u8> {
 }
 
 pub fn extract_headers_and_data_from_binary_message(
-    data: Vec<u8>,
+    data: &[u8],
 ) -> Result<(Headers, Option<Vec<u8>>), crate::Error> {
     let header_length = ((data[0] as usize) << 8) + data[1] as usize;
-    let headers = String::from_utf8(data[2..2 + header_length].to_vec())
+    let headers = std::str::from_utf8(&data[2..2 + header_length])
         .map_err(|_| crate::Error::ParseError("Error parsing headers".to_string()))?;
     let data = if header_length + 2 < data.len() {
         Some(data[2 + header_length..].to_vec())
@@ -41,11 +41,11 @@ pub fn extract_headers_and_data_from_binary_message(
         None
     };
 
-    Ok((explode_headers_message(headers.as_str()), data))
+    Ok((explode_headers_message(headers), data))
 }
 
 pub fn extract_headers_and_data_from_text_message(
-    text: String,
+    text: &str,
 ) -> Result<(Headers, Option<String>), crate::Error> {
     let mut split_response = text.split(HEADER_JSON_SEPARATOR);
 
@@ -88,7 +88,7 @@ mod tests {
     #[test]
     fn explode_message() {
         let text = "X-RequestId:91067ed0-bd0d-4682-891f-446a95996c19\r\nContent-Type:application/json; charset=utf-8\r\nPath:audio.metadata\r\n\r\n{\"Metadata\": [{\"Type\": \"SessionEnd\",\"Data\": {\"Offset\": 11250000}}]}";
-        let result = extract_headers_and_data_from_text_message(text.to_string());
+        let result = extract_headers_and_data_from_text_message(text);
         match result {
             Ok((headers, data)) => {
                 assert_eq!(

--- a/src/connector/utils.rs
+++ b/src/connector/utils.rs
@@ -13,7 +13,7 @@ pub fn make_text_payload(headers: Headers, data: Option<&str>) -> String {
 pub fn make_binary_payload(headers: Headers, data: Option<&[u8]>) -> Vec<u8> {
     let headers = transform_headers_to_string(headers);
 
-    let data_length = if let Some(ref d) = data { d.len() } else { 0 };
+    let data_length = if let Some(d) = data { d.len() } else { 0 };
 
     let header_buffer: Vec<_> = headers.bytes().collect();
     let header_length = header_buffer.len();
@@ -22,7 +22,7 @@ pub fn make_binary_payload(headers: Headers, data: Option<&[u8]>) -> Vec<u8> {
     payload[1] = (header_length & 0xff) as u8;
     payload[2..2 + header_length].copy_from_slice(&header_buffer);
 
-    if let Some(ref d) = data {
+    if let Some(d) = data {
         payload[2 + header_length..].copy_from_slice(d);
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use async_channel::SendError;
 use serde::Deserialize;
 use std::fmt::Debug;
 use std::result;
@@ -16,6 +15,7 @@ pub enum Error {
     InternalError(String),
     RuntimeError(String),
     ServerDisconnect(String),
+    ConnectionError(String),
     Forbidden,
     TooManyRequests,
     BadRequest,
@@ -39,6 +39,12 @@ impl From<serde_json::Error> for Error {
     }
 }
 
+impl<T> From<tokio::sync::mpsc::error::SendError<T>> for Error {
+    fn from(e: tokio::sync::mpsc::error::SendError<T>) -> Self {
+        Error::InternalError(e.to_string())
+    }
+}
+
 impl From<&str> for Error {
     fn from(s: &str) -> Self {
         Error::InternalError(s.to_string())
@@ -54,11 +60,5 @@ impl From<String> for Error {
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
         Error::IOError(e.to_string())
-    }
-}
-
-impl<T: Debug> From<SendError<T>> for Error {
-    fn from(e: SendError<T>) -> Self {
-        Error::InternalError(e.to_string())
     }
 }

--- a/src/recognizer/client.rs
+++ b/src/recognizer/client.rs
@@ -30,30 +30,19 @@ impl Client {
     pub async fn connect(auth: Auth, config: Config) -> crate::Result<Self> {
         let mut url = Url::parse(
             format!(
-                "wss://{}.stt.speech{}",
+                "wss://{}.stt.speech{}/speech/recognition/{}/cognitiveservices/v1",
                 auth.region,
-                get_azure_hostname_from_region(auth.region.as_str())
-            )
-            .as_str(),
-        )?;
-
-        url.set_path(
-            format!(
-                "/speech/recognition/{}/cognitiveservices/v1",
+                get_azure_hostname_from_region(auth.region.as_str()),
                 config.mode.as_str()
             )
             .as_str(),
-        );
+        )?;
 
         let lang = config
             .languages
             .first()
             .expect("Select at least one language!");
 
-        url.query_pairs_mut().append_pair(
-            "Ocp-Apim-Subscription-Key",
-            auth.subscription.to_string().as_str(),
-        );
         url.query_pairs_mut()
             .append_pair("language", lang.to_string().as_str());
         url.query_pairs_mut()
@@ -78,10 +67,16 @@ impl Client {
                 .append_pair("X-ConnectionId", connection_id.as_str());
         }
 
-        let client_config =
-            ezsockets::ClientConfig::new(url.as_str()).max_initial_connect_attempts(3);
-
-        let client = BaseClient::connect(client_config).await?;
+        let client = BaseClient::connect(
+            tokio_websockets::ClientBuilder::new()
+                .uri(url.as_str())
+                .unwrap()
+                .add_header(
+                    "Ocp-Apim-Subscription-Key".try_into().unwrap(),
+                    auth.subscription.to_string().as_str().try_into().unwrap(),
+                ),
+        )
+        .await?;
         Ok(Self::new(client, config))
     }
 
@@ -109,21 +104,26 @@ impl Client {
         let config = self.config.clone();
         let request_id = session.request_id().to_string();
 
-        self.client.send_text(create_speech_config_message(
-            request_id.clone(),
-            &config,
-            &details,
-        ))?;
         self.client
-            .send_text(create_speech_context_message(request_id.clone(), &config))?;
+            .send_text(create_speech_config_message(
+                request_id.clone(),
+                &config,
+                &details,
+            ))
+            .await?;
+        self.client
+            .send_text(create_speech_context_message(request_id.clone(), &config))
+            .await?;
 
         // Here I'm moving away from the original code.
         // I'm not interest anymore in the audio headers, but in the content type of the stream.
-        self.client.send_binary(create_audio_message(
-            request_id.clone(),
-            Some(content_type),
-            None,
-        ))?;
+        self.client
+            .send_binary(create_audio_message(
+                request_id.clone(),
+                Some(content_type),
+                None,
+            ))
+            .await?;
 
         let client = self.client.clone();
         let session1 = session.clone();
@@ -136,12 +136,15 @@ impl Client {
             while let Some(chunk) = audio.next().await {
                 buffer.extend(chunk);
                 while buffer.len() >= BUFFER_SIZE {
-                    let data = buffer.drain(..BUFFER_SIZE).collect();
-                    if let Err(e) = client.send_binary(create_audio_message(
-                        session1.request_id().to_string(),
-                        None,
-                        Some(data),
-                    )) {
+                    let data: Vec<u8> = buffer.drain(..BUFFER_SIZE).collect();
+                    if let Err(e) = client
+                        .send_binary(create_audio_message(
+                            session1.request_id().to_string(),
+                            None,
+                            Some(&data),
+                        ))
+                        .await
+                    {
                         tracing::error!("Error: {:?}", e);
                         return;
                     }
@@ -149,11 +152,11 @@ impl Client {
             }
 
             while !buffer.is_empty() {
-                let data = buffer.drain(..BUFFER_SIZE).collect();
+                let data: Vec<u8> = buffer.drain(..BUFFER_SIZE).collect();
                 let _ = client.send_binary(create_audio_message(
                     session1.request_id().to_string(),
                     None,
-                    Some(data),
+                    Some(&data),
                 ));
             }
             // notify that we have finished sending the audio.

--- a/src/recognizer/client.rs
+++ b/src/recognizer/client.rs
@@ -153,18 +153,22 @@ impl Client {
 
             while !buffer.is_empty() {
                 let data: Vec<u8> = buffer.drain(..BUFFER_SIZE).collect();
-                let _ = client.send_binary(create_audio_message(
-                    session1.request_id().to_string(),
-                    None,
-                    Some(&data),
-                ));
+                let _ = client
+                    .send_binary(create_audio_message(
+                        session1.request_id().to_string(),
+                        None,
+                        Some(&data),
+                    ))
+                    .await;
             }
             // notify that we have finished sending the audio.
-            let _ = client.send_binary(create_audio_message(
-                session1.request_id().to_string(),
-                None,
-                None,
-            ));
+            let _ = client
+                .send_binary(create_audio_message(
+                    session1.request_id().to_string(),
+                    None,
+                    None,
+                ))
+                .await;
             session1.set_audio_completed(true);
         });
 

--- a/src/recognizer/utils.rs
+++ b/src/recognizer/utils.rs
@@ -24,7 +24,7 @@ pub(crate) fn create_speech_config_message(
             ),
         ],
         Some(
-            json!({
+            &json!({
                 "context": {
                     "system": config.device.system,
                     "os": config.device.os,
@@ -128,14 +128,14 @@ pub(crate) fn create_speech_context_message(request_id: String, config: &Config)
                     .to_string(),
             ),
         ],
-        Some(context.to_string()),
+        Some(&context.to_string()),
     )
 }
 
 pub(crate) fn create_audio_message(
     request_id: String,
     content_type: Option<ContentType>,
-    data: Option<Vec<u8>>,
+    data: Option<&[u8]>,
 ) -> Vec<u8> {
     let mut headers = vec![
         ("X-RequestId".to_string(), request_id),

--- a/src/synthesizer/utils.rs
+++ b/src/synthesizer/utils.rs
@@ -20,7 +20,7 @@ pub(crate) fn create_speech_config_message(request_id: String, config: &Config) 
             ),
         ],
         Some(
-            json!({"context":{"system":&config.device.system,"os":&config.device.os}}).to_string(),
+            &json!({"context":{"system":&config.device.system,"os":&config.device.os}}).to_string(),
         ),
     )
 }
@@ -42,7 +42,7 @@ pub(crate) fn create_synthesis_context_message(request_id: String, config: &Conf
             ("Path".to_string(), "synthesis.context".to_string()),
         ],
         Some(
-            json!({"synthesis":
+            &json!({"synthesis":
             {"audio":
                 {"metadataOptions":
                     {
@@ -62,7 +62,7 @@ pub(crate) fn create_synthesis_context_message(request_id: String, config: &Conf
     )
 }
 
-pub(crate) fn create_ssml_message(request_id: String, ssml: String) -> String {
+pub(crate) fn create_ssml_message(request_id: String, ssml: &str) -> String {
     make_text_payload(
         vec![
             (


### PR DESCRIPTION
Replaces `ezsockets` with `tokio-websockets`, which reduces the number of dependencies (thus improving compile times) and offers slightly improved performance.