### PR TITLE
Add unit and integration tests

### DIFF
--- a/tests/recognizer.rs
+++ b/tests/recognizer.rs
@@ -14,9 +14,9 @@ use tracing::{error, info};
 
 #[tokio::test]
 async fn integration_test_reconnect() {
-    tracing_subscriber::fmt()
+    let _ = tracing_subscriber::fmt()
         .with_max_level(tracing::Level::DEBUG)
-        .init();
+        .try_init();
 
     let orig_hook = panic::take_hook();
     panic::set_hook(Box::new(move |panic_info| {
@@ -142,9 +142,9 @@ async fn integration_test_reconnect() {
 
 #[tokio::test]
 async fn integration_test_recognizer() {
-    tracing_subscriber::fmt()
+    let _ = tracing_subscriber::fmt()
         .with_max_level(tracing::Level::DEBUG)
-        .init();
+        .try_init();
 
     let orig_hook = panic::take_hook();
     panic::set_hook(Box::new(move |panic_info| {


### PR DESCRIPTION
## Summary
- fix tracing setup in recognizer integration tests
- test Synthesizer utils message creation
- test StreamExt helpers

## Testing
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_6854023f96f8832fb367cdb6e0dabff7